### PR TITLE
allow for arbitrary strings to be post()ed

### DIFF
--- a/Zebra_cURL.php
+++ b/Zebra_cURL.php
@@ -1469,7 +1469,7 @@ class Zebra_cURL {
                     CURLOPT_HEADER          =>  1,
                     CURLOPT_NOBODY          =>  0,
                     CURLOPT_POST            =>  1,
-                    CURLOPT_POSTFIELDS      =>  http_build_query($values, NULL, '&'),
+                    CURLOPT_POSTFIELDS      =>  is_array($values) ? http_build_query($values, NULL, '&') : $values,
                     CURLOPT_BINARYTRANSFER  =>  null,
                     CURLOPT_HTTPGET         =>  null,
                     CURLOPT_FILE            =>  null,


### PR DESCRIPTION
Hey, 

I've a few use cases where I need to post() a JSON-encoded string instead of a `x-www-form-urlencoded`-encoded string. This commit allows for arbitrary strings to be sent.